### PR TITLE
Add support for system properties

### DIFF
--- a/src/main/java/org/zalando/zester/configuration/ZesterCommandLineState.java
+++ b/src/main/java/org/zalando/zester/configuration/ZesterCommandLineState.java
@@ -23,14 +23,17 @@ public class ZesterCommandLineState extends JavaCommandLineState {
 
     private final String testClassQualifiedName;
     private final String targetClasses;
+    private final String vmOptions;
     private ConsoleView consoleView;
 
     protected ZesterCommandLineState(@NotNull ExecutionEnvironment environment,
                                      String testClassQualifiedName,
-                                     String targetClasses) {
+                                     String targetClasses,
+                                     String vmOptions) {
         super(environment);
         this.testClassQualifiedName = testClassQualifiedName;
         this.targetClasses = targetClasses;
+        this.vmOptions = vmOptions;
     }
 
     @Override
@@ -44,21 +47,24 @@ public class ZesterCommandLineState extends JavaCommandLineState {
         javaParameters.getClassPath().add(pitJavaParameters.getPitJarPath());
         javaParameters.getClassPath().add(pitJavaParameters.getPitCommandLineJarPath());
 
-        ParametersList programParametersList = javaParameters.getProgramParametersList();
+        ParametersList programParameters = javaParameters.getProgramParametersList();
 
-        programParametersList.add("--reportDir");
-        programParametersList.add(pitJavaParameters.getReportDirPath());
+        programParameters.add("--reportDir");
+        programParameters.add(pitJavaParameters.getReportDirPath());
 
-        programParametersList.add("--sourceDirs");
-        programParametersList.add(pitJavaParameters.getSourceDirPath());
+        programParameters.add("--sourceDirs");
+        programParameters.add(pitJavaParameters.getSourceDirPath());
 
-        programParametersList.add("--targetClasses");
-        programParametersList.add(pitJavaParameters.getTargetClasses());
+        programParameters.add("--targetClasses");
+        programParameters.add(pitJavaParameters.getTargetClasses());
 
-        programParametersList.add("--targetTests");
-        programParametersList.add(pitJavaParameters.getTargetTests());
+        programParameters.add("--targetTests");
+        programParameters.add(pitJavaParameters.getTargetTests());
 
         JavaParametersUtil.configureProject(project, javaParameters, JavaParameters.JDK_AND_CLASSES_AND_TESTS, null);
+
+        ParametersList vmParameters = javaParameters.getVMParametersList();
+        vmParameters.addParametersString(vmOptions);
 
         return javaParameters;
     }

--- a/src/main/java/org/zalando/zester/configuration/ZesterRunConfiguration.java
+++ b/src/main/java/org/zalando/zester/configuration/ZesterRunConfiguration.java
@@ -43,9 +43,11 @@ public class ZesterRunConfiguration extends ModuleBasedConfiguration<JavaRunConf
 
     private static final String TEST_CLASS_PATH = "TEST_CLASS_PATH";
     private static final String TARGET_CLASS_PATH = "TARGET_CLASS_PATH";
+    private static final String VM_OPTIONS = "VM_OPTIONS";
 
     private String targetTestClassQualifiedName;
     private String targetClasses;
+    private String vmOptions;
 
     public ZesterRunConfiguration(String name,
                                   @NotNull JavaRunConfigurationModule configurationModule,
@@ -67,36 +69,22 @@ public class ZesterRunConfiguration extends ModuleBasedConfiguration<JavaRunConf
     @Override
     public RunProfileState getState(@NotNull Executor executor,
                                     @NotNull ExecutionEnvironment environment) throws ExecutionException {
-        return new ZesterCommandLineState(environment, getTargetTestClassQualifiedName(), targetClasses);
+        return new ZesterCommandLineState(environment,
+                getTargetTestClassQualifiedName(), getTargetClasses(), getVmOptions());
     }
-
-    public void setTargetTestClassQualifiedName(String targetTestClassQualifiedName) {
-        this.targetTestClassQualifiedName = targetTestClassQualifiedName;
-    }
-
-    public String getTargetTestClassQualifiedName() {
-        return targetTestClassQualifiedName;
-    }
-
-    public void setTargetClasses(String targetClasses) {
-        this.targetClasses = targetClasses;
-    }
-
-    public String getTargetClasses() {
-        return targetClasses;
-    }
-
 
     @Override
     public void writeExternal(final Element element) throws WriteExternalException {
         JDOMExternalizer.write(element, TEST_CLASS_PATH, targetTestClassQualifiedName);
         JDOMExternalizer.write(element, TARGET_CLASS_PATH, targetClasses);
+        JDOMExternalizer.write(element, VM_OPTIONS, vmOptions);
     }
 
     @Override
     public void readExternal(final Element element) throws InvalidDataException {
         targetTestClassQualifiedName = JDOMExternalizer.readString(element, TEST_CLASS_PATH);
         targetClasses = JDOMExternalizer.readString(element, TARGET_CLASS_PATH);
+        vmOptions = JDOMExternalizer.readString(element, VM_OPTIONS);
     }
 
     @Override
@@ -164,4 +152,29 @@ public class ZesterRunConfiguration extends ModuleBasedConfiguration<JavaRunConf
         }
         return null;
     }
+
+    public void setTargetTestClassQualifiedName(String targetTestClassQualifiedName) {
+        this.targetTestClassQualifiedName = targetTestClassQualifiedName;
+    }
+
+    public String getTargetTestClassQualifiedName() {
+        return targetTestClassQualifiedName;
+    }
+
+    public void setTargetClasses(String targetClasses) {
+        this.targetClasses = targetClasses;
+    }
+
+    public String getTargetClasses() {
+        return targetClasses;
+    }
+
+    public String getVmOptions() {
+        return vmOptions;
+    }
+
+    public void setVmOptions(String vmOptions) {
+        this.vmOptions = vmOptions;
+    }
+
 }

--- a/src/main/java/org/zalando/zester/settings/ZesterConfigurationForm.form
+++ b/src/main/java/org/zalando/zester/settings/ZesterConfigurationForm.form
@@ -10,10 +10,10 @@
     <children>
       <component id="d0c1b" class="javax.swing.JLabel">
         <constraints>
-          <grid row="1" column="0" row-span="4" col-span="1" vsize-policy="0" hsize-policy="0" anchor="9" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
-          <text value="Test class"/>
+          <text value="Test class:"/>
         </properties>
       </component>
       <component id="695c6" class="com.intellij.openapi.ui.TextFieldWithBrowseButton" binding="targetTestClassQualifiedName">
@@ -30,10 +30,10 @@
       </component>
       <component id="6e510" class="javax.swing.JLabel">
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="9" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
-          <text value="Target classes"/>
+          <text value="Target classes:"/>
         </properties>
       </component>
       <vspacer id="56eda">
@@ -41,6 +41,22 @@
           <grid row="4" column="1" row-span="3" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
+      <component id="47100" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="VM Options:"/>
+        </properties>
+      </component>
+      <component id="611ea" class="com.intellij.ui.RawCommandLineEditor" binding="vmOptions">
+        <constraints>
+          <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value=""/>
+        </properties>
+      </component>
     </children>
   </grid>
 </form>

--- a/src/main/java/org/zalando/zester/settings/ZesterSettingsEditor.java
+++ b/src/main/java/org/zalando/zester/settings/ZesterSettingsEditor.java
@@ -9,6 +9,7 @@ import com.intellij.openapi.ui.TextFieldWithBrowseButton;
 import com.intellij.psi.JavaPsiFacade;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.ui.RawCommandLineEditor;
 import org.jetbrains.annotations.NotNull;
 import org.zalando.zester.configuration.ZesterRunConfiguration;
 
@@ -19,22 +20,26 @@ public class ZesterSettingsEditor extends SettingsEditor<ZesterRunConfiguration>
     private TextFieldWithBrowseButton targetTestClassQualifiedName;
     private TextFieldWithBrowseButton targetClasses;
     private JPanel mainPanel;
+    private RawCommandLineEditor vmOptions;
 
     public ZesterSettingsEditor(Project project) {
         setupTestClassBrowser(project);
         setupTargetClassesBrowser(project);
+        vmOptions.setDialogCaption("VM Options");
     }
 
     @Override
     protected void resetEditorFrom(ZesterRunConfiguration zesterRunConfiguration) {
         targetTestClassQualifiedName.setText(zesterRunConfiguration.getTargetTestClassQualifiedName());
         targetClasses.setText(zesterRunConfiguration.getTargetClasses());
+        vmOptions.setText(zesterRunConfiguration.getVmOptions());
     }
 
     @Override
     protected void applyEditorTo(ZesterRunConfiguration zesterRunConfiguration) throws ConfigurationException {
         zesterRunConfiguration.setTargetTestClassQualifiedName(getTargetTestClassQualifiedNameAsText());
         zesterRunConfiguration.setTargetClasses(getTargetClassesAsText());
+        zesterRunConfiguration.setVmOptions(getVmOptionsAsText());
     }
 
     @NotNull
@@ -49,6 +54,10 @@ public class ZesterSettingsEditor extends SettingsEditor<ZesterRunConfiguration>
 
     private String getTargetClassesAsText() {
         return targetClasses.getText();
+    }
+
+    private String getVmOptionsAsText() {
+        return vmOptions.getText();
     }
 
     private void setupTestClassBrowser(Project project) {


### PR DESCRIPTION
- Zester configuration allows to specify "VM Options",
similar to unit test runners.

Fixes #1